### PR TITLE
resolve bug: occupied until time

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -35,7 +35,7 @@ function Room ({ name }) {
         const endDate = new Date(End)
         if (acc) {
           const accEndDate = new Date(acc.End)
-          if (accEndDate + SIXTEEN_MINUTES > startDate) {
+          if (new Date(accEndDate.getTime() + SIXTEEN_MINUTES) > startDate) {
             return ({ Start, End })
           } else {
             return acc


### PR DESCRIPTION
The occupied until time was actually not working properly. The "occupied until" field  was just set to the end time of the current event.

To reproduce the bug just look at the time shown for BC03