### PR TITLE
Fix dates offsets

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -11,9 +11,9 @@ const ONE_DAY = new Date(NOW.getTime() + 24 * 60 * 60 * 1000)
 const HOURGLASS = 60 * 60 * 1000
 const SIXTEEN_MINUTES = 16 * 60 * 1000
 
-function parseDate(dateString) {
+function parseDate (dateString) {
   // See https://stackoverflow.com/a/5619588
-  return new Date(dateString + "+02:00")
+  return new Date(dateString + '+02:00')
 }
 
 function Room ({ name, loaded }) {
@@ -40,7 +40,6 @@ function Room ({ name, loaded }) {
       const currentEvent = parsedRoomOccupancy.reduce((acc, { Start, End, Text }) => {
         const startDate = parseDate(Start)
         const endDate = parseDate(End)
-        console.log(End, endDate)
         if (acc) {
           const accEndDate = new Date(acc.End)
           if (new Date(accEndDate.getUTCMilliseconds() + SIXTEEN_MINUTES) > startDate) {


### PR DESCRIPTION
Fixes #8.

See [SO](https://stackoverflow.com/a/5619588):

> **But wait!** Just using the "ISO format" doesn't work reliably by itself. String are sometimes parsed as UTC and sometimes as localtime (based on browser vendor and version). The best practice should always be to store dates as UTC and make computations as UTC.

And [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date):

> **Note:** parsing of date strings with the Date constructor (and Date.parse, they are equivalent) is strongly discouraged due to browser differences and inconsistencies. Support for RFC 2822 format strings is by convention only. Support for ISO 8601 formats differs in that date-only strings (e.g. "1970-01-01") are treated as UTC, not local.

With my changes, it *should* work. But it might need more testing 😉

A more future- and bulletproof solution might be to use a library like [d3-date-format](https://github.com/d3/d3-time-format/) or [momentjs](https://momentjs.com/).