### PR TITLE
Add winter time support

### DIFF
--- a/src/Room.js
+++ b/src/Room.js
@@ -13,7 +13,8 @@ const SIXTEEN_MINUTES = 16 * 60 * 1000
 
 function parseDate (dateString) {
   // See https://stackoverflow.com/a/5619588
-  return new Date(dateString + '+02:00')
+  let offset = NOW.getTimezoneOffset() == -60 ? '+01:00' : '+02:00'
+  return new Date(dateString + offset)
 }
 
 function Room ({ name, loaded }) {


### PR DESCRIPTION
Hello,

Just wanted to thank you for the work, it's really nice to have all rooms at a single place. Just one thing has been irritating me the last few weeks as winter time started, as the time slots where 'stuck' in summer time.

So I'm making this pull request to simply add support for winter time, as the offset is UTC+1 in winter (and UTC+2 in summer). As this website is supposed to be used by people in CEST timezone, I think it was fair to use `Date.getTimezoneOffset` instead of adding a new dependency like `momentjs`.

Cheers for good work,
Tim.